### PR TITLE
Fix: Wait for clear command to execute before reusing terminal

### DIFF
--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -168,6 +168,7 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 					} else {
 						terminal.sendText('clear');
 					}
+					await timeout(200); // add a small delay to ensure the command is processed, see #240953
 				}
 			}
 


### PR DESCRIPTION
clear command was in the middle of executing while the main (debugger) command started executing. Adding a small timeout to make sure the clear command executes before allowing the main command to be sent to the terminal.


this would happen when the `settings.json` has these settings:
```JSON
{
  "debug.terminal.clearBeforeReusing": true,
  "terminal.integrated.focusAfterRun": "terminal",
}
```




<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
